### PR TITLE
Removed 204 error to fix compiler errors.

### DIFF
--- a/src/HttpResponse.cpp
+++ b/src/HttpResponse.cpp
@@ -44,9 +44,3 @@ void operator<<(Stream& aStream, const HttpResponse& aResponse) {
     
     aResponse.printBody(aStream);
 }
-
-/**
- * Global defined err204 : HTTP 204 No Content.
- * Note : using this status, "the client SHOULD NOT change its document view..."    
- */
-Err204 err204;

--- a/src/HttpResponse.h
+++ b/src/HttpResponse.h
@@ -125,14 +125,4 @@ public:
     
 };
 
-class Err204 : public HttpResponseStatic {
-public:
-    Err204() :
-        HttpResponseStatic(NULL, 0) {
-            status(204);
-        };
-};
-
-extern Err204 err204;
-
 #endif // __HTTP_RESPONSE_H__


### PR DESCRIPTION
The 204 section of the header file causes the error:
error: converting to ‘String’ from initializer list would use explicit constructor ‘String::String(int, unsigned char) in line 131 of HttpResponse.h
Since it appears that the 204 error is not needed by the metasploit relay, I am suggesting removal.
I was able to test and run this version on a v0.6.2 version of a particle photon carloop.  I was also able to verify a metasploit connection after installing this version of the library.